### PR TITLE
Fix staging argocd server external secrets sync

### DIFF
--- a/infrastructure/staging/argocd-external-secrets-provider.tf
+++ b/infrastructure/staging/argocd-external-secrets-provider.tf
@@ -1,0 +1,55 @@
+data "aws_iam_policy_document" "external_secrets_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "external_secrets_permissions" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecrets"
+    ]
+
+    resources = [
+      "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:/infra/argo/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "external_secrets_policy" {
+  name   = "${aws_eks_cluster.eks.name}-external-secrets-access"
+  policy = data.aws_iam_policy_document.external_secrets_permissions.json
+}
+
+resource "aws_iam_role" "external_secrets" {
+  name               = "${aws_eks_cluster.eks.name}-external-secrets-provider"
+  assume_role_policy = data.aws_iam_policy_document.external_secrets_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "external_secrets" {
+  policy_arn = aws_iam_policy.external_secrets_policy.arn
+  role       = aws_iam_role.external_secrets.name
+}
+
+resource "aws_eks_pod_identity_association" "external_secrets" {
+  cluster_name    = aws_eks_cluster.eks.name
+  namespace       = "external-secrets"
+  service_account = "external-secrets"
+  role_arn        = aws_iam_role.external_secrets.arn
+}


### PR DESCRIPTION
- Provision external secrets IAM role and an eks-pod-identity association to be used by ESO to access secrets manager.