### PR TITLE
Feat/aws multi acct architecture

### DIFF
--- a/infrastructure/bootstrap/01-org/README.md
+++ b/infrastructure/bootstrap/01-org/README.md
@@ -1,0 +1,10 @@
+# bootstrap/01-org
+
+This creates the AWS organization, OUs and member accounts.
+
+## Directory structure
+
+├── bootstrap/
+│ ├── 01-org/
+│ ├── 02-sso-assignments/
+│ └── 03-shared-backend/

--- a/infrastructure/bootstrap/01-org/locals.tf
+++ b/infrastructure/bootstrap/01-org/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  common_tags = {
+    ManagedBy = "terraform"
+    Project   = "zeus"
+    GitRepo   = "basebandit/zeus:infrastructure/bootstrap/01-org"
+  }
+}

--- a/infrastructure/bootstrap/01-org/main.tf
+++ b/infrastructure/bootstrap/01-org/main.tf
@@ -1,0 +1,75 @@
+data "aws_organizations_organization" "this" {}
+
+resource "aws_organizations_organizational_unit" "infrastructure" {
+  name      = "Infrastructure"
+  parent_id = data.aws_organizations_organization.this.roots[0].id
+}
+
+resource "aws_organizations_organizational_unit" "workloads" {
+  name      = "Workloads"
+  parent_id = data.aws_organizations_organization.this.roots[0].id
+}
+
+resource "aws_organizations_account" "shared_services" {
+  name      = "shared"
+  email     = "${var.account_email_prefix}+aws-shared-services@gmail.com"
+  parent_id = aws_organizations_organizational_unit.infrastructure.id
+
+  close_on_deletion = false
+
+  tags = merge(local.common_tags, {
+    Environment = "shared"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_organizations_account" "dev" {
+  name      = "dev"
+  email     = "${var.account_email_prefix}+aws-dev@gmail.com"
+  parent_id = aws_organizations_organizational_unit.workloads.id
+
+  close_on_deletion = false
+
+  tags = merge(local.common_tags, {
+    Environment = "dev"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_organizations_account" "staging" {
+  name      = "staging"
+  email     = "${var.account_email_prefix}+aws-staging@gmail.com"
+  parent_id = aws_organizations_organizational_unit.workloads.id
+
+  close_on_deletion = false
+
+  tags = merge(local.common_tags, {
+    Environment = "staging"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_organizations_account" "prod" {
+  name      = "prod"
+  email     = "${var.account_email_prefix}+aws-prod@gmail.com"
+  parent_id = aws_organizations_organizational_unit.workloads.id
+
+  close_on_deletion = false
+
+  tags = merge(local.common_tags, {
+    Environment = "prod"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infrastructure/bootstrap/01-org/outputs.tf
+++ b/infrastructure/bootstrap/01-org/outputs.tf
@@ -1,0 +1,24 @@
+output "management_account_id" {
+  description = "The management account (admin) — never destroyed."
+  value       = data.aws_organizations_organization.this.master_account_id
+}
+
+output "organization_root_id" {
+  value = data.aws_organizations_organization.this.roots[0].id
+}
+
+output "shared_services_account_id" {
+  value = aws_organizations_account.shared_services.id
+}
+
+output "dev_account_id" {
+  value = aws_organizations_account.dev.id
+}
+
+output "staging_account_id" {
+  value = aws_organizations_account.staging.id
+}
+
+output "prod_account_id" {
+  value = aws_organizations_account.prod.id
+}

--- a/infrastructure/bootstrap/01-org/provider.tf
+++ b/infrastructure/bootstrap/01-org/provider.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+
+  # Hard guard: error out at init if the profile resolves to any account
+  # other than the management account. Cheap insurance for org-root ops.
+  allowed_account_ids = [var.management_account_id]
+}

--- a/infrastructure/bootstrap/01-org/variables.tf
+++ b/infrastructure/bootstrap/01-org/variables.tf
@@ -1,0 +1,22 @@
+variable "aws_region" {
+  description = "AWS region for the provider."
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "aws_profile" {
+  description = "AWS CLI/SSO profile for the management account."
+  type        = string
+  default     = "bootstrap_admin"
+}
+
+variable "management_account_id" {
+  description = "Expected management account ID. Guards against applying with wrong credentials."
+  type        = string
+  default     = "060309844053"
+}
+
+# Must be the local part of an inbox you control e.g. <account_email_prefix>@gmail.com
+variable "account_email_prefix" {
+  type = string
+}

--- a/infrastructure/bootstrap/01-org/versions.tf
+++ b/infrastructure/bootstrap/01-org/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/infrastructure/bootstrap/02-sso-assignments/README.md
+++ b/infrastructure/bootstrap/02-sso-assignments/README.md
@@ -1,0 +1,3 @@
+# bootstrap/02-sso-assignments
+
+This assigns our IAM Identity Center admin permission set to all accounts.

--- a/infrastructure/bootstrap/02-sso-assignments/main.tf
+++ b/infrastructure/bootstrap/02-sso-assignments/main.tf
@@ -1,0 +1,30 @@
+data "aws_ssoadmin_instances" "this" {}
+
+data "aws_identitystore_user" "admin" {
+  identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = var.identity_center_username
+    }
+  }
+}
+
+data "aws_ssoadmin_permission_set" "admin" {
+  instance_arn = tolist(data.aws_ssoadmin_instances.this.arns)[0]
+  name         = var.permission_set_name
+}
+
+resource "aws_ssoadmin_account_assignment" "admin" {
+  for_each = var.account_ids
+
+  instance_arn       = tolist(data.aws_ssoadmin_instances.this.arns)[0]
+  permission_set_arn = data.aws_ssoadmin_permission_set.admin.arn
+
+  principal_id   = data.aws_identitystore_user.admin.user_id
+  principal_type = "USER"
+
+  target_id   = each.value
+  target_type = "AWS_ACCOUNT"
+}

--- a/infrastructure/bootstrap/02-sso-assignments/provider.tf
+++ b/infrastructure/bootstrap/02-sso-assignments/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}

--- a/infrastructure/bootstrap/02-sso-assignments/variables.tf
+++ b/infrastructure/bootstrap/02-sso-assignments/variables.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  description = "AWS region for the provider."
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "aws_profile" {
+  description = "AWS CLI/SSO profile for the management account."
+  type        = string
+  default     = "bootstrap_admin"
+}
+
+variable "identity_center_username" {
+  description = "Identity Store UserName of the user to grant access."
+  type        = string
+}
+
+variable "permission_set_name" {
+  description = "Permission set to assign across the accounts."
+  type        = string
+  default     = "AdministratorAccess"
+}
+
+variable "account_ids" {
+  description = "Map of name => account ID to grant the permission set on."
+  type        = map(string)
+}

--- a/infrastructure/bootstrap/02-sso-assignments/versions.tf
+++ b/infrastructure/bootstrap/02-sso-assignments/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">=  1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/infrastructure/bootstrap/03-shared-backend/main.tf
+++ b/infrastructure/bootstrap/03-shared-backend/main.tf
@@ -1,0 +1,63 @@
+resource "aws_s3_bucket" "tf_state" {
+  bucket = var.state_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+
+resource "aws_s3_bucket" "cloudtrail_logs" {
+  bucket = var.cloudtrail_logs_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/infrastructure/bootstrap/03-shared-backend/outputs.tf
+++ b/infrastructure/bootstrap/03-shared-backend/outputs.tf
@@ -1,0 +1,7 @@
+output "terraform_state_bucket_name" {
+  value = aws_s3_bucket.tf_state.bucket
+}
+
+output "cloudtrail_logs_bucket_name" {
+  value = aws_s3_bucket.cloudtrail_logs.bucket
+}

--- a/infrastructure/bootstrap/03-shared-backend/provider.tf
+++ b/infrastructure/bootstrap/03-shared-backend/provider.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+
+  assume_role {
+    role_arn     = "arn:aws:iam::${var.shared_services_account_id}:role/OrganizationAccountAccessRole"
+    session_name = "tf-shared-backend-bootstrap"
+  }
+}

--- a/infrastructure/bootstrap/03-shared-backend/variables.tf
+++ b/infrastructure/bootstrap/03-shared-backend/variables.tf
@@ -1,0 +1,25 @@
+variable "aws_region" {
+  description = "AWS region for the provider."
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "aws_profile" {
+  description = "AWS CLI/SSO profile for the management account."
+  type        = string
+}
+
+variable "shared_services_account_id" {
+  description = "Account ID where the state and logs buckets are created."
+  type        = string
+}
+
+variable "state_bucket_name" {
+  description = "Name of the Terraform state bucket."
+  type        = string
+}
+
+variable "cloudtrail_logs_bucket_name" {
+  description = "Name of the CloudTrail logs bucket."
+  type        = string
+}

--- a/infrastructure/bootstrap/03-shared-backend/versions.tf
+++ b/infrastructure/bootstrap/03-shared-backend/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

  Adds Terraform bootstrap infrastructure for the AWS multi-account setup.

  ## Changes

  - Added 01-org bootstrap configuration for AWS Organizations, OUs, and member accounts.
  - Added guarded AWS provider configuration for organization-level operations.
  - Added organization outputs for management, shared services, dev, staging, and prod accounts.
  - Added 02-sso-assignments configuration for IAM Identity Center account assignments.
  - Added 03-shared-backend configuration for Terraform state and CloudTrail logs S3 buckets.
  - Added basic README documentation for the bootstrap stages.