### PR TITLE
Add organization monthly budget alerts

### DIFF
--- a/infrastructure/bootstrap/organisation/budgets.tf
+++ b/infrastructure/bootstrap/organisation/budgets.tf
@@ -1,0 +1,31 @@
+resource "aws_budgets_budget" "organization_monthly_cost" {
+  name         = "zeus-organization-monthly-cost"
+  budget_type  = "COST"
+  limit_amount = tostring(var.organization_monthly_budget_usd)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.budget_alert_email]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = [var.budget_alert_email]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.budget_alert_email]
+  }
+}

--- a/infrastructure/bootstrap/organisation/variables.tf
+++ b/infrastructure/bootstrap/organisation/variables.tf
@@ -20,3 +20,13 @@ variable "management_account_id" {
 variable "account_email_prefix" {
   type = string
 }
+
+variable "organization_monthly_budget_usd" {
+  description = "Monthly AWS cost budget threshold for the organization."
+  type        = number
+}
+
+variable "budget_alert_email" {
+  description = "Email address that receives organization budget alerts."
+  type        = string
+}


### PR DESCRIPTION
## Summary

  Adds organization-wide AWS monthly budget alerts.

  ## Changes

  - Added a monthly AWS cost budget in the management account.
  - Added email alerts at 80% actual, 100% forecasted, and 100% actual spend.
  - Added budget variables without committing sensitive values.