### PR TITLE
Add dev environment: VPC, EKS, ArgoCD via reusable modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,13 @@ coverage/
 .env.local
 .env.*.local
 
+# Secrets — never commit. ArgoCD repo creds come from SecretsManager via External Secrets.
+git-repo-secret.yaml
+*.pem
+*-key.pem
+id_rsa
+id_ed25519
+
 # IDEs
 .vscode/
 .idea/

--- a/charts/argocd/argocd-apps/_project-app-sets/dev-project-app-set.yaml
+++ b/charts/argocd/argocd-apps/_project-app-sets/dev-project-app-set.yaml
@@ -1,0 +1,75 @@
+projects:
+  dev-project-apps:
+    namespace: argocd
+    additionalLabels: {}
+    additionalAnnotations: {}
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    description: A logical grouping of dev applications in the dev basebandit eks cluster
+    sourceRepos:
+      - "git@github.com:basebandit/zeus.git"
+      - "https://argoproj.github.io/argo-helm"
+    # This meta-project only creates Applications and AppProjects (via the
+    # argocd-apps chart) into the argocd namespace, so scope it to that.
+    destinations:
+      - namespace: argocd
+        server: https://kubernetes.default.svc
+    clusterResourceWhitelist: []
+    clusterResourceBlacklist: []
+    namespaceResourceBlacklist: []
+    orphanedResources:
+      warn: false
+    roles: []
+    namespaceResourceWhitelist:
+      - group: argoproj.io
+        kind: Application
+      - group: argoproj.io
+        kind: AppProject
+applicationsets:
+  dev-project-app-set:
+    namespace: argocd
+    additionalLabels: {}
+    additionalAnnotations: {}
+    goTemplate: true
+    generators:
+      - git:
+          repoURL: git@github.com:basebandit/zeus.git
+          revision: main
+          files:
+            - path: charts/argocd/argocd-apps/dev/*.yaml
+    template:
+      metadata:
+        name: '{{ index (splitList "." .path.filenameNormalized) 0 }}'
+        labels: {}
+        annotations: {}
+      spec:
+        project: 'dev-project-apps'
+        sources:
+          - repoURL: "https://argoproj.github.io/argo-helm"
+            chart: argocd-apps
+            targetRevision: 2.0.2
+            helm:
+              valueFiles:
+                - $values/charts/argocd/argocd-apps/dev/{{ .path.filename }}
+          - repoURL: "git@github.com:basebandit/zeus.git"
+            targetRevision: main
+            ref: values
+        destination:
+          server: "https://kubernetes.default.svc"
+          namespace: argocd
+        syncPolicy:
+          automated:
+            prune: true
+            selfHeal: true
+        # Server-side apply makes ArgoCD a polite field manager: it owns the
+        # fields it sets and tolerates other controllers (HPA, Istio injector,
+        # admission webhooks) owning theirs, instead of fighting over drift.
+        # Setting it here applies it to every app this ApplicationSet generates.
+        syncOptions:
+          - Validate=false
+          - PruneLast=true
+          - CreateNamespace=true
+          - ServerSideApply=true
+    syncPolicy:
+      preserveResourceOnDeletion: true
+      applicationSync: create-update

--- a/charts/argocd/argocd-apps/dev/dev-orders.yaml
+++ b/charts/argocd/argocd-apps/dev/dev-orders.yaml
@@ -1,0 +1,66 @@
+projects:
+  dev-orders-apps:
+    namespace: argocd
+    additionalLabels: {}
+    additionalAnnotations: {}
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    description: A logical grouping of orders applications in the dev basebandit eks cluster
+    sourceRepos:
+      - "git@github.com:basebandit/zeus.git"
+    destinations:
+      - namespace: orders
+        server: https://kubernetes.default.svc
+    clusterResourceWhitelist: []
+    clusterResourceBlacklist: []
+    namespaceResourceBlacklist:
+      - group: ""
+        kind: ResourceQuota
+      - group: ""
+        kind: LimitRange
+      - group: ""
+        kind: NetworkPolicy
+    orphanedResources:
+      warn: false
+    roles: []
+    namespaceResourceWhitelist:
+      - group: "*"
+        kind: "*"
+applications:
+  orders:
+    namespace: argocd
+    project: dev-orders-apps
+    additionalLabels: {}
+    additionalAnnotations:
+      argocd-image-updater.argoproj.io/image-list: orders=892880329567.dkr.ecr.eu-central-1.amazonaws.com/orders
+      argocd-image-updater.argoproj.io/orders.update-strategy: semver
+      argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/zeus-repo
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    revisionHistoryLimit: 10
+    source:
+      repoURL: git@github.com:basebandit/zeus.git
+      path: charts/orders
+      helm:
+        valueFiles:
+          - dev-values.yaml
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: orders
+    syncPolicy:
+      automated:
+        allowEmpty: false
+        prune: true
+        selfHeal: true
+      retry:
+        backoff:
+          duration: 5s
+          factor: 2
+          maxDuration: 3m
+        limit: 5
+      syncOptions:
+        - Validate=true
+        - CreateNamespace=true
+        - PrunePropagationPolicy=foreground
+        - PruneLast=true
+        - ServerSideApply=true

--- a/charts/argocd/argocd-apps/dev/dev-payments.yaml
+++ b/charts/argocd/argocd-apps/dev/dev-payments.yaml
@@ -1,0 +1,66 @@
+projects:
+  dev-payments-apps:
+    namespace: argocd
+    additionalLabels: {}
+    additionalAnnotations: {}
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    description: A logical grouping of payments applications in the dev basebandit eks cluster
+    sourceRepos:
+      - "git@github.com:basebandit/zeus.git"
+    destinations:
+      - namespace: payments
+        server: https://kubernetes.default.svc
+    clusterResourceWhitelist: []
+    clusterResourceBlacklist: []
+    namespaceResourceBlacklist:
+      - group: ""
+        kind: ResourceQuota
+      - group: ""
+        kind: LimitRange
+      - group: ""
+        kind: NetworkPolicy
+    orphanedResources:
+      warn: false
+    roles: []
+    namespaceResourceWhitelist:
+      - group: "*"
+        kind: "*"
+applications:
+  payments:
+    namespace: argocd
+    project: dev-payments-apps
+    additionalLabels: {}
+    additionalAnnotations:
+      argocd-image-updater.argoproj.io/image-list: payments=892880329567.dkr.ecr.eu-central-1.amazonaws.com/payments
+      argocd-image-updater.argoproj.io/payments.update-strategy: semver
+      argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/zeus-repo
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    revisionHistoryLimit: 10
+    source:
+      repoURL: git@github.com:basebandit/zeus.git
+      path: charts/payments
+      helm:
+        valueFiles:
+          - dev-values.yaml
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: payments
+    syncPolicy:
+      automated:
+        allowEmpty: false
+        prune: false
+        selfHeal: true
+      retry:
+        backoff:
+          duration: 5s
+          factor: 2
+          maxDuration: 3m
+        limit: 5
+      syncOptions:
+        - Validate=true
+        - CreateNamespace=true
+        - PrunePropagationPolicy=foreground
+        - PruneLast=true
+        - ServerSideApply=true

--- a/charts/argocd/argocd-server/dev-argocd-image-updater-values.yaml
+++ b/charts/argocd/argocd-server/dev-argocd-image-updater-values.yaml
@@ -1,0 +1,24 @@
+---
+serviceAccount:
+  name: argocd-image-updater
+
+# Images are replicated from the shared account into this (dev) account's ECR,
+# so the registry is same-account. The pod-identity role attached to this
+# service account (created in module argocd-platform) has ECR read on this
+# account, so a plain get-authorization-token is enough — no assume-role.
+authScripts:
+  enabled: true
+  scripts:
+    auth.sh: |
+      #!/bin/sh
+      aws ecr --region eu-central-1 get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -d
+
+config:
+  registries:
+    - name: ECR
+      api_url: https://892880329567.dkr.ecr.eu-central-1.amazonaws.com
+      prefix: 892880329567.dkr.ecr.eu-central-1.amazonaws.com
+      ping: yes
+      insecure: no
+      credentials: ext:/scripts/auth.sh
+      credsexpire: 10h

--- a/charts/argocd/argocd-server/dev-argocd-values.yaml
+++ b/charts/argocd/argocd-server/dev-argocd-values.yaml
@@ -1,0 +1,40 @@
+configs:
+  secret:
+    # argocd-secret is created via External Secrets (see module argocd-platform).
+    createSecret: false
+  params:
+    server.insecure: true # TLS terminated at the ingress
+
+# Dev runs on small nodes — single replicas, no redis-ha.
+controller:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+server:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+repoServer:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+redis-ha:
+  enabled: false

--- a/infrastructure/environments/dev/argocd.tf
+++ b/infrastructure/environments/dev/argocd.tf
@@ -1,0 +1,25 @@
+module "argocd" {
+  source = "../../modules/argocd"
+
+  providers = {
+    aws        = aws
+    helm       = helm
+    kubernetes = kubernetes
+    kubectl    = kubectl
+  }
+
+  env          = local.env
+  cluster_name = module.eks.cluster_name
+  aws_region   = var.aws_region
+
+  # Images replicate from shared into this account, so the registry is local.
+  ecr_account_id    = coalesce(var.ecr_account_id, var.dev_account_id)
+  ecr_region        = var.ecr_region
+  ecr_pull_role_arn = var.ecr_pull_role_arn # null: same-account, no assume-role needed
+
+  argocd_values_file        = "${path.module}/../../../charts/argocd/argocd-server/dev-argocd-values.yaml"
+  argocd_apps_values_file   = "${path.module}/../../../charts/argocd/argocd-apps/_project-app-sets/dev-project-app-set.yaml"
+  image_updater_values_file = "${path.module}/../../../charts/argocd/argocd-server/dev-argocd-image-updater-values.yaml"
+
+  depends_on = [module.eks]
+}

--- a/infrastructure/environments/dev/backend.tf
+++ b/infrastructure/environments/dev/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "zeus-tfstate-890387920780"
+    key          = "dev/terraform.tfstate"
+    region       = "eu-west-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infrastructure/environments/dev/ecr-access.tf
+++ b/infrastructure/environments/dev/ecr-access.tf
@@ -1,0 +1,31 @@
+# Cross-account ECR (dev side)
+#
+# Images live in the shared account and are replicated into this account by the
+# shared account's aws_ecr_replication_configuration. This registry policy grants
+# the shared account permission to create the replica repositories and push the
+# replicated images. Once replicated, the node group pulls same-account (its
+# AmazonEC2ContainerRegistryReadOnly is enough) and ArgoCD Image Updater watches
+# this account's own registry.
+
+data "aws_iam_policy_document" "ecr_replication" {
+  statement {
+    sid    = "AllowSharedAccountReplication"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.shared_account_id}:root"]
+    }
+
+    actions = [
+      "ecr:CreateRepository",
+      "ecr:ReplicateImage",
+    ]
+
+    resources = ["arn:aws:ecr:${var.aws_region}:${var.dev_account_id}:repository/*"]
+  }
+}
+
+resource "aws_ecr_registry_policy" "replication" {
+  policy = data.aws_iam_policy_document.ecr_replication.json
+}

--- a/infrastructure/environments/dev/ecr-repos.tf
+++ b/infrastructure/environments/dev/ecr-repos.tf
@@ -1,0 +1,14 @@
+# Pre-create the replica repositories in this account so they carry a lifecycle
+# policy (and scan-on-push). Replicated repos that ECR auto-creates inherit
+# NOTHING from the source — no lifecycle — so images would accumulate forever.
+# Shared-account replication pushes into these existing repos.
+module "ecr" {
+  source = "../../modules/ecr"
+
+  repository_names = ["orders", "payments", "inventory"]
+  keep_last_images = 20
+
+  # Same-account: nodes pull directly, no cross-account pull policy or reader role.
+  pull_account_ids      = []
+  reader_principal_arns = []
+}

--- a/infrastructure/environments/dev/eks.tf
+++ b/infrastructure/environments/dev/eks.tf
@@ -1,0 +1,11 @@
+module "eks" {
+  source = "../../modules/eks"
+
+  env             = local.env
+  cluster_name    = local.cluster_full_name
+  cluster_version = var.cluster_version
+  subnet_ids      = module.vpc.private_subnet_ids
+
+  node_instance_types = var.node_instance_types
+  node_scaling        = var.node_scaling
+}

--- a/infrastructure/environments/dev/iam.tf
+++ b/infrastructure/environments/dev/iam.tf
@@ -1,0 +1,9 @@
+module "terraform_executor" {
+  source = "../../modules/terraform-executor-role"
+
+  environment        = local.env
+  bootstrap_role_arn = var.bootstrap_role_arn
+
+  # AdministratorAccess is acceptable for dev — iterate quickly without permission friction.
+  managed_policy_arns = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+}

--- a/infrastructure/environments/dev/locals.tf
+++ b/infrastructure/environments/dev/locals.tf
@@ -1,0 +1,15 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  region   = var.aws_region
+  env      = "dev"
+  org_name = "basebandit"
+
+  cluster_name      = "basebandit-lab"
+  cluster_full_name = "${local.env}-${local.cluster_name}-cluster"
+
+  # Two AZs, matching the two-subnet-pair VPC layout.
+  azs = slice(data.aws_availability_zones.available.names, 0, 2)
+}

--- a/infrastructure/environments/dev/outputs.tf
+++ b/infrastructure/environments/dev/outputs.tf
@@ -1,0 +1,34 @@
+output "executor_role_arn" {
+  description = "ARN of the Terraform executor role. Provide this to the shared-services bootstrap role as an executor_role_arn."
+  value       = module.terraform_executor.role_arn
+}
+
+output "vpc_id" {
+  description = "ID of the dev VPC."
+  value       = module.vpc.vpc_id
+}
+
+output "cluster_name" {
+  description = "Name of the dev EKS cluster."
+  value       = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "Kubernetes API endpoint of the dev EKS cluster."
+  value       = module.eks.cluster_endpoint
+}
+
+output "node_role_arn" {
+  description = "Node group role ARN. Grant this ECR pull in the shared account's repository policy."
+  value       = module.eks.node_role_arn
+}
+
+output "image_updater_role_arn" {
+  description = "ArgoCD Image Updater role ARN. Grant this ECR read in the shared account's repository policy."
+  value       = module.argocd.image_updater_role_arn
+}
+
+output "argocd_secrets_path_prefix" {
+  description = "SecretsManager path prefix to seed ArgoCD config under (admin password, server key, repo creds)."
+  value       = module.argocd.secrets_path_prefix
+}

--- a/infrastructure/environments/dev/provider.tf
+++ b/infrastructure/environments/dev/provider.tf
@@ -1,0 +1,55 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.49"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0.2"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# In-cluster providers are configured from the EKS module outputs. These values
+# are unknown until the cluster exists, so the first run needs a two-phase apply:
+#   terraform apply -target=module.eks
+#   terraform apply
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_ca)
+    token                  = data.aws_eks_cluster_auth.this.token
+  }
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_ca)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "kubectl" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_ca)
+  token                  = data.aws_eks_cluster_auth.this.token
+  load_config_file       = false
+}

--- a/infrastructure/environments/dev/variables.tf
+++ b/infrastructure/environments/dev/variables.tf
@@ -1,0 +1,66 @@
+variable "aws_region" {
+  description = "AWS region."
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "dev_account_id" {
+  description = "AWS account ID of the dev member account. Get this from: cd management && terraform output dev_account_id"
+  type        = string
+}
+
+variable "bootstrap_role_arn" {
+  description = "ARN of the GHA bootstrap role in the Shared Services account. Get this from: cd shared-services && terraform output bootstrap_role_arn"
+  type        = string
+}
+
+# --- Workload: EKS ----------------------------------------------------------
+variable "cluster_version" {
+  description = "Kubernetes version for the EKS cluster."
+  type        = string
+  default     = "1.32"
+}
+
+variable "node_instance_types" {
+  description = "EC2 instance types for the general node group."
+  type        = list(string)
+  default     = ["t3.small"]
+}
+
+variable "node_scaling" {
+  description = "Autoscaling bounds for the general node group (dev is kept small)."
+  type = object({
+    min     = number
+    desired = number
+    max     = number
+  })
+  default = {
+    min     = 2
+    desired = 2
+    max     = 4
+  }
+}
+
+# --- Workload: cross-account ECR (registry lives in the shared account) ------
+variable "shared_account_id" {
+  description = "AWS account ID of the shared account (Terraform state + ECR). Get from: cd management && terraform output shared_services_account_id"
+  type        = string
+}
+
+variable "ecr_account_id" {
+  description = "AWS account ID that owns the ECR repositories ArgoCD Image Updater watches. Defaults to the shared account."
+  type        = string
+  default     = null
+}
+
+variable "ecr_region" {
+  description = "Region of the ECR repositories."
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "ecr_pull_role_arn" {
+  description = "Cross-account role in the ECR-owning account that the image-updater assumes for ECR read/auth. Null for same-account ECR."
+  type        = string
+  default     = null
+}

--- a/infrastructure/environments/dev/vpc.tf
+++ b/infrastructure/environments/dev/vpc.tf
@@ -1,0 +1,8 @@
+module "vpc" {
+  source = "../../modules/vpc"
+
+  env                = local.env
+  cluster_full_name  = local.cluster_full_name
+  azs                = local.azs
+  single_nat_gateway = true
+}

--- a/infrastructure/environments/shared-services/ecr.tf
+++ b/infrastructure/environments/shared-services/ecr.tf
@@ -1,0 +1,38 @@
+# Container registry for all environments. Images are built/pushed here once
+# (shared is the source of truth) and ECR replication copies each image into the
+# dev/staging/prod accounts, so clusters pull from their OWN account registry
+# (same-account auth — no cross-account token juggling on the nodes).
+module "ecr" {
+  source = "../../modules/ecr"
+
+  repository_names = ["orders", "payments", "inventory"]
+
+  # Belt-and-suspenders: still allow direct cross-account pull. With replication
+  # in place this is a fallback, not the primary path.
+  pull_account_ids = [
+    var.dev_account_id,
+    var.staging_account_id,
+    var.prod_account_id,
+  ]
+
+  # Reader role is unnecessary once images replicate into each account; leave
+  # empty. Set principals here only if a cluster must read the shared registry
+  # directly instead of its replica.
+  reader_principal_arns = []
+}
+
+# Registry-level replication (one config per account/region). Copies every repo
+# in this account to the same region of each workload account.
+resource "aws_ecr_replication_configuration" "this" {
+  replication_configuration {
+    rule {
+      dynamic "destination" {
+        for_each = [var.dev_account_id, var.staging_account_id, var.prod_account_id]
+        content {
+          region      = var.aws_region
+          registry_id = destination.value
+        }
+      }
+    }
+  }
+}

--- a/infrastructure/environments/shared-services/iam.tf
+++ b/infrastructure/environments/shared-services/iam.tf
@@ -1,0 +1,45 @@
+# GitHub OIDC provider — allows GitHub Actions to authenticate to AWS without
+# long-lived access keys.
+module "github_oidc" {
+  source = "../../modules/github-oidc-provider"
+}
+
+# Bootstrap role — assumed by GHA via OIDC, then assumes executor roles in each
+# member account to run Terraform.
+#
+# Executor role ARNs are pre-computed from account IDs using the deterministic
+# naming convention set in the terraform-executor-role module (terraform-executor-{env}).
+# This avoids a circular dependency — shared-services can be deployed before
+# dev/staging/prod as long as the account IDs are known from management outputs.
+module "gha_bootstrap" {
+  source = "../../modules/gha-bootstrap-role"
+
+  oidc_provider_arn = module.github_oidc.provider_arn
+  github_org        = var.github_org
+
+  allowed_repos = [
+    {
+      repo = var.github_repo
+      subjects = [
+        "ref:refs/heads/main",
+        "environment:dev",
+        "environment:staging",
+        "environment:prod",
+        "pull_request",
+      ]
+    }
+  ]
+
+  executor_role_arns = [
+    "arn:aws:iam::${var.dev_account_id}:role/terraform-executor-dev",
+    "arn:aws:iam::${var.staging_account_id}:role/terraform-executor-staging",
+    "arn:aws:iam::${var.prod_account_id}:role/terraform-executor-prod",
+    "arn:aws:iam::${var.audit_account_id}:role/terraform-executor-audit",
+  ]
+
+  # Executor roles hold AdministratorAccess (dev/staging) or a scoped inline policy (prod),
+  # so the bootstrap role itself does not need direct S3/KMS access.
+  state_bucket_arn     = null
+  state_lock_table_arn = null
+  state_kms_key_arn    = null
+}

--- a/infrastructure/environments/shared-services/locals.tf
+++ b/infrastructure/environments/shared-services/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  region   = var.aws_region
+  env      = "shared-services"
+  org_name = "basebandit"
+}

--- a/infrastructure/environments/shared-services/outputs.tf
+++ b/infrastructure/environments/shared-services/outputs.tf
@@ -1,0 +1,19 @@
+output "bootstrap_role_arn" {
+  description = "ARN of the GHA bootstrap role. Use this as var.bootstrap_role_arn in dev, staging, and prod."
+  value       = module.gha_bootstrap.role_arn
+}
+
+output "github_oidc_provider_arn" {
+  description = "ARN of the GitHub OIDC provider."
+  value       = module.github_oidc.provider_arn
+}
+
+output "ecr_repository_urls" {
+  description = "Map of service name to ECR repository URL."
+  value       = module.ecr.repository_urls
+}
+
+output "ecr_reader_role_arn" {
+  description = "ARN of the cross-account ECR reader role. Pass as var.ecr_pull_role_arn in workload envs."
+  value       = module.ecr.reader_role_arn
+}

--- a/infrastructure/environments/shared-services/providers.tf
+++ b/infrastructure/environments/shared-services/providers.tf
@@ -1,0 +1,27 @@
+data "aws_caller_identity" "current" {}
+
+provider "aws" {
+  region = local.region
+
+  assume_role {
+    role_arn = "arn:aws:iam::${var.shared_services_account_id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.49"
+    }
+  }
+
+  # backend "s3" {
+  #   bucket       = "basebandit-terraform-state-<management-account-id>"
+  #   key          = "environments/shared-services/terraform.tfstate"
+  #   region       = "eu-central-1"
+  #   use_lockfile = true
+  # }
+}

--- a/infrastructure/environments/shared-services/variables.tf
+++ b/infrastructure/environments/shared-services/variables.tf
@@ -1,0 +1,42 @@
+variable "aws_region" {
+  description = "AWS region."
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "shared_services_account_id" {
+  description = "AWS account ID of the shared-services member account. Get from: cd management && terraform output shared_services_account_id"
+  type        = string
+}
+
+variable "dev_account_id" {
+  description = "AWS account ID of the dev member account. Get from: cd management && terraform output dev_account_id"
+  type        = string
+}
+
+variable "staging_account_id" {
+  description = "AWS account ID of the staging member account. Get from: cd management && terraform output staging_account_id"
+  type        = string
+}
+
+variable "prod_account_id" {
+  description = "AWS account ID of the prod member account. Get from: cd management && terraform output prod_account_id"
+  type        = string
+}
+
+variable "audit_account_id" {
+  description = "AWS account ID of the audit member account. Get from: cd management && terraform output audit_account_id"
+  type        = string
+}
+
+variable "github_org" {
+  description = "GitHub organization name that owns the infrastructure repo."
+  type        = string
+  default     = "basebandit"
+}
+
+variable "github_repo" {
+  description = "GitHub repository name that runs Terraform via GHA."
+  type        = string
+  default     = "infrastructure"
+}

--- a/infrastructure/modules/argocd/main.tf
+++ b/infrastructure/modules/argocd/main.tf
@@ -1,0 +1,194 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  secrets_path_prefix = coalesce(var.secrets_path_prefix, "/infra/argo/${var.cluster_name}")
+}
+
+# ===========================================================================
+# ArgoCD server
+# ===========================================================================
+resource "helm_release" "argocd" {
+  name             = "argocd"
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argo-cd"
+  version          = var.argocd_chart_version
+  namespace        = "argocd"
+  create_namespace = true
+  timeout          = var.helm_timeout
+
+  values = [file(var.argocd_values_file)]
+}
+
+# ===========================================================================
+# External Secrets Operator (delivers ArgoCD admin + repo secrets from SecretsManager)
+# ===========================================================================
+data "aws_iam_policy_document" "external_secrets_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "external_secrets_perms" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecrets",
+    ]
+    resources = [
+      "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:${local.secrets_path_prefix}/*",
+      "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:${local.secrets_path_prefix}*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "external_secrets" {
+  name               = "${var.cluster_name}-external-secrets-provider"
+  assume_role_policy = data.aws_iam_policy_document.external_secrets_assume.json
+}
+
+resource "aws_iam_policy" "external_secrets" {
+  name   = "${var.cluster_name}-external-secrets-access"
+  policy = data.aws_iam_policy_document.external_secrets_perms.json
+}
+
+resource "aws_iam_role_policy_attachment" "external_secrets" {
+  role       = aws_iam_role.external_secrets.name
+  policy_arn = aws_iam_policy.external_secrets.arn
+}
+
+resource "aws_eks_pod_identity_association" "external_secrets" {
+  cluster_name    = var.cluster_name
+  namespace       = "external-secrets"
+  service_account = "external-secrets"
+  role_arn        = aws_iam_role.external_secrets.arn
+}
+
+resource "helm_release" "external_secrets" {
+  name             = "external-secrets"
+  repository       = "https://charts.external-secrets.io"
+  chart            = "external-secrets"
+  namespace        = "external-secrets"
+  create_namespace = true
+  timeout          = var.helm_timeout
+
+  depends_on = [aws_eks_pod_identity_association.external_secrets]
+}
+
+# ===========================================================================
+# ArgoCD config manifests (replaces the legacy null_resource + kubectl --profile)
+# ===========================================================================
+resource "kubectl_manifest" "cluster_secret_store" {
+  yaml_body = templatefile("${path.module}/templates/external-secrets-provider.yaml.tftpl", {
+    region = var.aws_region
+  })
+
+  depends_on = [helm_release.external_secrets]
+}
+
+resource "kubectl_manifest" "argocd_secret" {
+  yaml_body = templatefile("${path.module}/templates/argocd-secret.yaml.tftpl", {
+    secrets_path_prefix = local.secrets_path_prefix
+  })
+
+  depends_on = [kubectl_manifest.cluster_secret_store, helm_release.argocd]
+}
+
+resource "kubectl_manifest" "git_repo_secret" {
+  yaml_body = templatefile("${path.module}/templates/git-repo-secret.yaml.tftpl", {
+    secrets_path_prefix = local.secrets_path_prefix
+  })
+
+  depends_on = [kubectl_manifest.cluster_secret_store, helm_release.argocd]
+}
+
+# ===========================================================================
+# ArgoCD Image Updater
+# ===========================================================================
+data "aws_iam_policy_document" "image_updater_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "image_updater" {
+  name               = "${var.cluster_name}-argocd-image-updater"
+  assume_role_policy = data.aws_iam_policy_document.image_updater_assume.json
+}
+
+# Same-account ECR read. AmazonEC2ContainerRegistryReadOnly covers
+# GetAuthorizationToken (account-scoped) and pull/list on this account's repos.
+resource "aws_iam_role_policy_attachment" "image_updater_ecr" {
+  role       = aws_iam_role.image_updater.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+# Cross-account ECR: when the registry lives in another account (e.g. shared),
+# allow the image-updater role to assume the reader role provided by that
+# account. The auth script in the Helm values uses this to fetch a token.
+resource "aws_iam_role_policy" "image_updater_assume_ecr" {
+  count = var.ecr_pull_role_arn != null ? 1 : 0
+  name  = "${var.cluster_name}-image-updater-assume-ecr"
+  role  = aws_iam_role.image_updater.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "sts:AssumeRole"
+      Resource = var.ecr_pull_role_arn
+    }]
+  })
+}
+
+resource "aws_eks_pod_identity_association" "image_updater" {
+  cluster_name    = var.cluster_name
+  namespace       = "argocd"
+  service_account = "argocd-image-updater"
+  role_arn        = aws_iam_role.image_updater.arn
+}
+
+resource "helm_release" "image_updater" {
+  name       = "argocd-image-updater"
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-image-updater"
+  version    = var.image_updater_chart_version
+  namespace  = "argocd"
+  timeout    = var.helm_timeout
+
+  values = [file(var.image_updater_values_file)]
+
+  depends_on = [helm_release.argocd]
+}
+
+# ===========================================================================
+# ArgoCD Applications / ApplicationSet (app-of-apps via the argocd-apps chart)
+# ===========================================================================
+resource "helm_release" "argocd_apps" {
+  name             = "argocd-apps"
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argocd-apps"
+  version          = var.argocd_apps_chart_version
+  namespace        = "argocd"
+  create_namespace = true
+  timeout          = var.helm_timeout
+
+  values = [file(var.argocd_apps_values_file)]
+
+  # Needs the repo credentials secret to exist so generated Applications can sync.
+  depends_on = [
+    helm_release.argocd,
+    kubectl_manifest.git_repo_secret,
+  ]
+}

--- a/infrastructure/modules/argocd/outputs.tf
+++ b/infrastructure/modules/argocd/outputs.tf
@@ -1,0 +1,14 @@
+output "image_updater_role_arn" {
+  description = "ARN of the ArgoCD Image Updater IAM role (grant ECR access to this in the registry-owning account)."
+  value       = aws_iam_role.image_updater.arn
+}
+
+output "external_secrets_role_arn" {
+  description = "ARN of the External Secrets IAM role."
+  value       = aws_iam_role.external_secrets.arn
+}
+
+output "secrets_path_prefix" {
+  description = "SecretsManager path prefix this cluster reads ArgoCD config from. Seed these secrets before applying ArgoCD config."
+  value       = local.secrets_path_prefix
+}

--- a/infrastructure/modules/argocd/templates/argocd-secret.yaml.tftpl
+++ b/infrastructure/modules/argocd/templates/argocd-secret.yaml.tftpl
@@ -1,0 +1,32 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-secret
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-secret
+    app.kubernetes.io/part-of: argocd
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: argocd-secret
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: argocd-secret
+          app.kubernetes.io/part-of: argocd
+  data:
+  - secretKey: admin.password
+    remoteRef:
+      key: ${secrets_path_prefix}/admin-password
+  - secretKey: admin.passwordMtime
+    remoteRef:
+      key: ${secrets_path_prefix}/admin-password-mtime
+  - secretKey: server.secretkey
+    remoteRef:
+      key: ${secrets_path_prefix}/server-secret-key

--- a/infrastructure/modules/argocd/templates/external-secrets-provider.yaml.tftpl
+++ b/infrastructure/modules/argocd/templates/external-secrets-provider.yaml.tftpl
@@ -1,0 +1,9 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: aws-secretsmanager
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: ${region}

--- a/infrastructure/modules/argocd/templates/git-repo-secret.yaml.tftpl
+++ b/infrastructure/modules/argocd/templates/git-repo-secret.yaml.tftpl
@@ -1,0 +1,37 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zeus-repo
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: zeus-repo
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: repository
+  data:
+    - secretKey: url
+      remoteRef:
+        key: ${secrets_path_prefix}/zeus-repo-config
+        property: url
+    - secretKey: sshPrivateKey
+      remoteRef:
+        key: ${secrets_path_prefix}/zeus-repo-config
+        property: sshPrivateKey
+    - secretKey: enableLfs
+      remoteRef:
+        key: ${secrets_path_prefix}/zeus-repo-config
+        property: enableLfs
+    - secretKey: insecure
+      remoteRef:
+        key: ${secrets_path_prefix}/zeus-repo-config
+        property: insecure

--- a/infrastructure/modules/argocd/variables.tf
+++ b/infrastructure/modules/argocd/variables.tf
@@ -1,0 +1,76 @@
+variable "env" {
+  type        = string
+  description = "Environment name (dev, staging, prod)."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Fully-qualified EKS cluster name. Used to name IAM roles and as the SecretsManager path segment (/infra/argo/<cluster_name>/...)."
+}
+
+variable "aws_region" {
+  type        = string
+  description = "Region of this account's SecretsManager (where External Secrets reads ArgoCD config from)."
+}
+
+# -- ArgoCD config in SecretsManager -----------------------------------------
+variable "secrets_path_prefix" {
+  type        = string
+  description = "SecretsManager path prefix holding ArgoCD config (admin password, server key, repo creds). Defaults to /infra/argo/<cluster_name>."
+  default     = null
+}
+
+# -- ECR (image updater) -----------------------------------------------------
+variable "ecr_account_id" {
+  type        = string
+  description = "AWS account ID that owns the ECR repositories ArgoCD Image Updater watches."
+}
+
+variable "ecr_region" {
+  type        = string
+  description = "Region of the ECR repositories."
+}
+
+variable "ecr_pull_role_arn" {
+  type        = string
+  description = "Optional cross-account role to assume for ECR read/auth when ECR lives in another account. Null for same-account ECR."
+  default     = null
+}
+
+# -- Helm values files (rendered/owned by the caller) ------------------------
+variable "argocd_values_file" {
+  type        = string
+  description = "Path to the argo-cd Helm values file."
+}
+
+variable "argocd_apps_values_file" {
+  type        = string
+  description = "Path to the argocd-apps Helm values file (projects + ApplicationSet)."
+}
+
+variable "image_updater_values_file" {
+  type        = string
+  description = "Path to the argocd-image-updater Helm values file."
+}
+
+# -- Chart versions ----------------------------------------------------------
+variable "argocd_chart_version" {
+  type    = string
+  default = "8.2.2"
+}
+
+variable "argocd_apps_chart_version" {
+  type    = string
+  default = "2.0.2"
+}
+
+variable "image_updater_chart_version" {
+  type    = string
+  default = "0.12.3"
+}
+
+variable "helm_timeout" {
+  type        = number
+  description = "Timeout in seconds for Helm releases."
+  default     = 600
+}

--- a/infrastructure/modules/argocd/versions.tf
+++ b/infrastructure/modules/argocd/versions.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.49"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0.2"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+    # gavinbunney/kubectl applies raw manifests at apply-time without a
+    # plan-time CRD check, which the official kubernetes_manifest resource
+    # cannot do. The External Secrets CRDs (ClusterSecretStore, ExternalSecret)
+    # do not exist until the external-secrets Helm release is installed, so we
+    # need a resource that tolerates that ordering.
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14"
+    }
+  }
+}

--- a/infrastructure/modules/ecr/main.tf
+++ b/infrastructure/modules/ecr/main.tf
@@ -1,0 +1,105 @@
+resource "aws_ecr_repository" "this" {
+  for_each = toset(var.repository_names)
+
+  name                 = each.value
+  image_tag_mutability = var.image_tag_mutability
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each   = aws_ecr_repository.this
+  repository = each.value.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last ${var.keep_last_images} images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = var.keep_last_images
+      }
+      action = { type = "expire" }
+    }]
+  })
+}
+
+# Cross-account pull: allow workload accounts to pull images. Pulling still
+# requires an ECR auth token issued by THIS account (see the reader role below
+# or an imagePullSecret) — the repository policy only authorizes the layers.
+data "aws_iam_policy_document" "repo" {
+  count = length(var.pull_account_ids) > 0 ? 1 : 0
+
+  statement {
+    sid    = "AllowCrossAccountPull"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [for id in var.pull_account_ids : "arn:aws:iam::${id}:root"]
+    }
+
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:DescribeImages",
+      "ecr:ListImages",
+    ]
+  }
+}
+
+resource "aws_ecr_repository_policy" "this" {
+  for_each   = length(var.pull_account_ids) > 0 ? aws_ecr_repository.this : {}
+  repository = each.value.name
+  policy     = data.aws_iam_policy_document.repo[0].json
+}
+
+# Reader role: image-updaters in the workload accounts assume this (it lives in
+# the ECR-owning account) so GetAuthorizationToken returns a token valid for
+# this registry.
+data "aws_iam_policy_document" "reader_trust" {
+  count = length(var.reader_principal_arns) > 0 ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "AWS"
+      identifiers = var.reader_principal_arns
+    }
+  }
+}
+
+data "aws_iam_policy_document" "reader_perms" {
+  count = length(var.reader_principal_arns) > 0 ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:DescribeImages",
+      "ecr:ListImages",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "reader" {
+  count              = length(var.reader_principal_arns) > 0 ? 1 : 0
+  name               = var.reader_role_name
+  assume_role_policy = data.aws_iam_policy_document.reader_trust[0].json
+}
+
+resource "aws_iam_role_policy" "reader" {
+  count  = length(var.reader_principal_arns) > 0 ? 1 : 0
+  name   = "${var.reader_role_name}-perms"
+  role   = aws_iam_role.reader[0].id
+  policy = data.aws_iam_policy_document.reader_perms[0].json
+}

--- a/infrastructure/modules/ecr/outputs.tf
+++ b/infrastructure/modules/ecr/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_urls" {
+  description = "Map of repository name to repository URL."
+  value       = { for k, r in aws_ecr_repository.this : k => r.repository_url }
+}
+
+output "reader_role_arn" {
+  description = "ARN of the cross-account ECR reader role (null if no reader principals configured)."
+  value       = length(var.reader_principal_arns) > 0 ? aws_iam_role.reader[0].arn : null
+}

--- a/infrastructure/modules/ecr/variables.tf
+++ b/infrastructure/modules/ecr/variables.tf
@@ -1,0 +1,38 @@
+variable "repository_names" {
+  type        = list(string)
+  description = "ECR repository names to create (e.g. orders, payments, inventory)."
+}
+
+variable "pull_account_ids" {
+  type        = list(string)
+  description = "AWS account IDs allowed to pull from these repositories (cross-account workload accounts)."
+  default     = []
+}
+
+variable "reader_principal_arns" {
+  type        = list(string)
+  description = "IAM principal ARNs allowed to assume the ECR reader role (e.g. the per-cluster ArgoCD Image Updater roles)."
+  default     = []
+}
+
+variable "reader_role_name" {
+  type        = string
+  description = "Name of the cross-account ECR reader role that image-updaters assume to list tags and fetch auth tokens."
+  default     = "zeus-ecr-reader"
+}
+
+variable "image_tag_mutability" {
+  type    = string
+  default = "IMMUTABLE"
+}
+
+variable "scan_on_push" {
+  type    = bool
+  default = true
+}
+
+variable "keep_last_images" {
+  type        = number
+  description = "Lifecycle policy: number of images to retain per repository."
+  default     = 20
+}

--- a/infrastructure/modules/ecr/versions.tf
+++ b/infrastructure/modules/ecr/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.49"
+    }
+  }
+}

--- a/infrastructure/modules/eks/main.tf
+++ b/infrastructure/modules/eks/main.tf
@@ -1,0 +1,106 @@
+# ---------------------------------------------------------------------------
+# Control plane
+# ---------------------------------------------------------------------------
+resource "aws_iam_role" "cluster" {
+  name = "${var.cluster_name}-eks-cluster"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "eks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "cluster" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = var.cluster_name
+  version  = var.cluster_version
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    endpoint_private_access = var.endpoint_private_access
+    endpoint_public_access  = var.endpoint_public_access
+    subnet_ids              = var.subnet_ids
+  }
+
+  access_config {
+    authentication_mode                         = "API"
+    bootstrap_cluster_creator_admin_permissions = true
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.cluster]
+}
+
+# ---------------------------------------------------------------------------
+# Node group
+# ---------------------------------------------------------------------------
+resource "aws_iam_role" "nodes" {
+  name = "${var.cluster_name}-eks-nodes"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "nodes" {
+  for_each = toset([
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+  ])
+  policy_arn = each.value
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_eks_node_group" "general" {
+  cluster_name    = aws_eks_cluster.this.name
+  version         = var.cluster_version
+  node_group_name = "general"
+  node_role_arn   = aws_iam_role.nodes.arn
+  subnet_ids      = var.subnet_ids
+
+  capacity_type  = var.node_capacity_type
+  instance_types = var.node_instance_types
+
+  scaling_config {
+    desired_size = var.node_scaling.desired
+    max_size     = var.node_scaling.max
+    min_size     = var.node_scaling.min
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  labels = {
+    role = "general"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.nodes]
+
+  # Let cluster-autoscaler manage desired_size without a Terraform diff.
+  lifecycle {
+    ignore_changes = [scaling_config[0].desired_size]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Pod Identity Agent (used instead of IRSA for service-account IAM)
+# ---------------------------------------------------------------------------
+resource "aws_eks_addon" "pod_identity" {
+  cluster_name  = aws_eks_cluster.this.name
+  addon_name    = "eks-pod-identity-agent"
+  addon_version = var.pod_identity_addon_version
+}

--- a/infrastructure/modules/eks/outputs.tf
+++ b/infrastructure/modules/eks/outputs.tf
@@ -1,0 +1,29 @@
+output "cluster_name" {
+  description = "Name of the EKS cluster."
+  value       = aws_eks_cluster.this.name
+}
+
+output "cluster_endpoint" {
+  description = "Kubernetes API server endpoint."
+  value       = aws_eks_cluster.this.endpoint
+}
+
+output "cluster_ca" {
+  description = "Base64-encoded certificate authority data for the cluster."
+  value       = aws_eks_cluster.this.certificate_authority[0].data
+}
+
+output "oidc_issuer" {
+  description = "OIDC issuer URL of the cluster."
+  value       = aws_eks_cluster.this.identity[0].oidc[0].issuer
+}
+
+output "node_role_name" {
+  description = "Name of the node group IAM role."
+  value       = aws_iam_role.nodes.name
+}
+
+output "node_role_arn" {
+  description = "ARN of the node group IAM role."
+  value       = aws_iam_role.nodes.arn
+}

--- a/infrastructure/modules/eks/variables.tf
+++ b/infrastructure/modules/eks/variables.tf
@@ -1,0 +1,64 @@
+variable "env" {
+  type        = string
+  description = "Environment name (dev, staging, prod)."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Fully-qualified EKS cluster name (e.g. dev-basebandit-lab-cluster). Used directly as the cluster name and as the prefix for its IAM roles."
+}
+
+variable "cluster_version" {
+  type        = string
+  description = "Kubernetes version for the EKS control plane and node group."
+  default     = "1.32"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs for the control plane ENIs and the node group (private subnets)."
+}
+
+variable "endpoint_public_access" {
+  type        = bool
+  description = "Expose the Kubernetes API endpoint publicly. Fine for dev; tighten for prod."
+  default     = true
+}
+
+variable "endpoint_private_access" {
+  type        = bool
+  description = "Expose the Kubernetes API endpoint inside the VPC."
+  default     = false
+}
+
+variable "node_instance_types" {
+  type        = list(string)
+  description = "EC2 instance types for the general node group."
+  default     = ["t3.small"]
+}
+
+variable "node_scaling" {
+  type = object({
+    min     = number
+    desired = number
+    max     = number
+  })
+  description = "Autoscaling bounds for the general node group."
+  default = {
+    min     = 2
+    desired = 3
+    max     = 6
+  }
+}
+
+variable "node_capacity_type" {
+  type        = string
+  description = "ON_DEMAND or SPOT for the general node group."
+  default     = "ON_DEMAND"
+}
+
+variable "pod_identity_addon_version" {
+  type        = string
+  description = "Version of the eks-pod-identity-agent addon."
+  default     = "v1.3.8-eksbuild.2"
+}

--- a/infrastructure/modules/eks/versions.tf
+++ b/infrastructure/modules/eks/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.49"
+    }
+  }
+}

--- a/infrastructure/modules/vpc/main.tf
+++ b/infrastructure/modules/vpc/main.tf
@@ -1,0 +1,110 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.env}-main"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.azs[count.index]
+
+  tags = {
+    "Name"                                           = "${var.env}-private-${var.azs[count.index]}"
+    "kubernetes.io/role/internal-elb"                = "1"
+    "kubernetes.io/cluster/${var.cluster_full_name}" = "owned"
+  }
+}
+
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    "Name"                                           = "${var.env}-public-${var.azs[count.index]}"
+    "kubernetes.io/role/elb"                         = "1"
+    "kubernetes.io/cluster/${var.cluster_full_name}" = "owned"
+  }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.env}-igw"
+  }
+}
+
+locals {
+  nat_count = var.single_nat_gateway ? 1 : 2
+}
+
+resource "aws_eip" "nat" {
+  count  = local.nat_count
+  domain = "vpc"
+
+  tags = {
+    Name = "${var.env}-nat-${count.index}"
+  }
+}
+
+resource "aws_nat_gateway" "nat" {
+  count         = local.nat_count
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = {
+    Name = "${var.env}-nat-${count.index}"
+  }
+
+  depends_on = [aws_internet_gateway.igw]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name = "${var.env}-public"
+  }
+}
+
+# One private route table per NAT gateway. With single_nat_gateway both private
+# subnets share one table; otherwise each AZ routes through its own NAT.
+resource "aws_route_table" "private" {
+  count  = local.nat_count
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat[count.index].id
+  }
+
+  tags = {
+    Name = "${var.env}-private-${count.index}"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[var.single_nat_gateway ? 0 : count.index].id
+}

--- a/infrastructure/modules/vpc/outputs.tf
+++ b/infrastructure/modules/vpc/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = aws_vpc.main.id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets (EKS nodes)."
+  value       = aws_subnet.private[*].id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets (internet-facing load balancers)."
+  value       = aws_subnet.public[*].id
+}

--- a/infrastructure/modules/vpc/variables.tf
+++ b/infrastructure/modules/vpc/variables.tf
@@ -1,0 +1,50 @@
+variable "env" {
+  type        = string
+  description = "Environment name (dev, staging, prod). Used to name and tag resources."
+}
+
+variable "cluster_full_name" {
+  type        = string
+  description = "Fully-qualified EKS cluster name (e.g. dev-basebandit-lab-cluster). Used for the kubernetes.io/cluster subnet tag so the AWS Load Balancer Controller and EKS can discover subnets."
+}
+
+variable "azs" {
+  type        = list(string)
+  description = "Two availability zones to spread subnets across."
+  validation {
+    condition     = length(var.azs) == 2
+    error_message = "Exactly two availability zones are required (zone1, zone2)."
+  }
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC."
+  default     = "10.0.0.0/16"
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "Two CIDR blocks for the private (node) subnets, one per AZ."
+  default     = ["10.0.0.0/19", "10.0.32.0/19"]
+  validation {
+    condition     = length(var.private_subnet_cidrs) == 2
+    error_message = "Exactly two private subnet CIDRs are required."
+  }
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Two CIDR blocks for the public (load balancer) subnets, one per AZ."
+  default     = ["10.0.64.0/19", "10.0.96.0/19"]
+  validation {
+    condition     = length(var.public_subnet_cidrs) == 2
+    error_message = "Exactly two public subnet CIDRs are required."
+  }
+}
+
+variable "single_nat_gateway" {
+  type        = bool
+  description = "When true, route both private subnets through one NAT gateway (cheaper, fine for non-prod). When false, one NAT gateway per AZ for HA."
+  default     = true
+}

--- a/infrastructure/modules/vpc/versions.tf
+++ b/infrastructure/modules/vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.49"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Provisions the **dev** workload account (`892880329567`) with VPC + EKS + ArgoCD, fitted to the multi-account model, by extracting reusable Terraform modules from the legacy staging stack.

## What's included

- **New reusable modules** (`infrastructure/modules/`):
  - `vpc` — VPC, 2x private + 2x public subnets, IGW, NAT (single/HA toggle), routes, EKS subnet tags.
  - `eks` — cluster + `general` node group + `eks-pod-identity-agent` addon. Fixes the staging `=` role-name bug.
  - `argocd` — ArgoCD, argocd-apps, image-updater, external-secrets + Pod Identity IAM. Replaces the `null_resource`/`kubectl --profile` bootstrap with a headless, CI-safe approach.
  - `ecr` — repos + cross-account pull policy + reader role.
- **Dev env** (`infrastructure/environments/dev/`) — single root, composes the modules.
- **Shared account** — ECR repos with replication to dev/staging/prod (images pulled same-account).
- **ArgoCD config** (`charts/argocd/.../dev/`) — scoped AppProjects, ApplicationSet pinned to `main`, `ServerSideApply=true`.

